### PR TITLE
mux: fix the volume ramp dividing integers and going NaN

### DIFF
--- a/internal/mux/export_test.go
+++ b/internal/mux/export_test.go
@@ -21,3 +21,21 @@ func (p *Player) IsRegistered() bool {
 	_, ok := p.p.mux.players[p.p]
 	return ok
 }
+
+// PrimeForMixing puts the player into the playing state with buf as its buffered
+// source data and a volume ramp from prevVolume to the current volume, without
+// registering the player with the mux. It is used to test the mixing directly.
+func (p *Player) PrimeForMixing(buf []byte, prevVolume float64) {
+	p.p.m.Lock()
+	defer p.p.m.Unlock()
+
+	p.p.state = playerPlay
+	p.p.buf = buf
+	p.p.prevVolume = prevVolume
+}
+
+// ReadBufferAndAdd mixes the buffered source data into buf and returns the number
+// of mixed samples.
+func (p *Player) ReadBufferAndAdd(buf []float32) int {
+	return p.p.readBufferAndAdd(buf)
+}

--- a/internal/mux/mux.go
+++ b/internal/mux/mux.go
@@ -488,7 +488,10 @@ func (p *playerImpl) readBufferAndAdd(buf []float32) int {
 	volume := float32(p.volume)
 
 	channelCount := p.mux.channelCount
-	rateDenom := float32(n / channelCount)
+	// The division must be done on floats, or a buffer with fewer samples than
+	// channels makes rateDenom 0 and the ramp rate 0/0, i.e. NaN, silencing the
+	// whole ramp.
+	rateDenom := float32(n) / float32(channelCount)
 
 	src := p.buf[:n*bitDepthInBytes]
 

--- a/internal/mux/mux_test.go
+++ b/internal/mux/mux_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -632,6 +633,60 @@ func TestInvalidVolumeWhilePlayingIsRecoverable(t *testing.T) {
 	}
 	if sum == 0 {
 		t.Error("the player stayed silent after a valid volume was set again")
+	}
+}
+
+// signedInt16LEBytes returns the little-endian 16-bit representation of the given values.
+func signedInt16LEBytes(values ...int16) []byte {
+	bs := make([]byte, 0, 2*len(values))
+	for _, v := range values {
+		bs = append(bs, byte(v), byte(v>>8))
+	}
+	return bs
+}
+
+// A volume ramp must not be dropped when fewer samples than the channel count
+// are buffered. With an integer division for the ramp denominator, the
+// denominator became 0 and the whole ramp became NaN, silencing the player.
+func TestVolumeRampWithFewerSamplesThanChannelsDoesNotSilence(t *testing.T) {
+	const half = 1 << 14
+
+	for _, tc := range []struct {
+		name         string
+		channelCount int
+		src          []byte
+	}{
+		// A stereo player with a single sample left in its buffer.
+		{"stereo with one sample", 2, signedInt16LEBytes(half)},
+		// A stereo player with a partial frame left in its buffer.
+		{"stereo with a partial frame", 2, signedInt16LEBytes(half, half, half)[:3]},
+		// A quadrophonic player with a single sample left in its buffer.
+		{"quad with one sample", 4, signedInt16LEBytes(half)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := mux.New(48000, tc.channelCount, mux.FormatSignedInt16LE)
+			p := newPlayer(t, m, &bytes.Reader{})
+			p.SetVolume(0.5)
+
+			// Ramp from the volume 1 to the volume 0.5.
+			p.PrimeForMixing(slices.Clone(tc.src), 1)
+
+			buf := make([]float32, len(tc.src)/mux.FormatSignedInt16LE.ByteLength())
+			if got, want := p.ReadBufferAndAdd(buf), len(buf); got != want {
+				t.Fatalf("mixed samples: got %d; want %d", got, want)
+			}
+
+			for i, got := range buf {
+				if math.IsNaN(float64(got)) {
+					t.Fatalf("buf[%d]: got NaN; want a finite value", i)
+				}
+				// The sample source is 0.5 and the volume is ramped from 1 to 0.5,
+				// so every mixed sample must lie in [0.25, 0.5].
+				if got < 0.25 || got > 0.5 {
+					t.Errorf("buf[%d]: got %v; want a value in [0.25, 0.5]", i, got)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/mux/mux_test.go
+++ b/internal/mux/mux_test.go
@@ -657,11 +657,23 @@ func TestVolumeRampWithFewerSamplesThanChannelsDoesNotSilence(t *testing.T) {
 		src          []byte
 	}{
 		// A stereo player with a single sample left in its buffer.
-		{"stereo with one sample", 2, signedInt16LEBytes(half)},
+		{
+			name:         "stereo with one sample",
+			channelCount: 2,
+			src:          signedInt16LEBytes(half),
+		},
 		// A stereo player with a partial frame left in its buffer.
-		{"stereo with a partial frame", 2, signedInt16LEBytes(half, half, half)[:3]},
+		{
+			name:         "stereo with a partial frame",
+			channelCount: 2,
+			src:          signedInt16LEBytes(half, half, half)[:3],
+		},
 		// A quadrophonic player with a single sample left in its buffer.
-		{"quad with one sample", 4, signedInt16LEBytes(half)},
+		{
+			name:         "quad with one sample",
+			channelCount: 4,
+			src:          signedInt16LEBytes(half),
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			m := mux.New(48000, tc.channelCount, mux.FormatSignedInt16LE)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please adhere to our Code of Conduct:
https://go.dev/conduct
-->

# What issue is this addressing?
<!-- Closes #<issue number> | Updates #<issue number> -->

No issue filed yet. Found during an audit of the mux package.

## What _type_ of issue is this addressing?
<!-- bug | feature | security -->

bug

## What this PR does | solves
<!-- Please be as descriptive as possible -->

`(*playerImpl).readBufferAndAdd` computed the volume ramp denominator as:

```go
rateDenom := float32(n / channelCount) // integer division
```

`n` is the number of samples to mix and `channelCount` the number of channels. When a playing buffer holds **fewer samples than channels** (n < channelCount, e.g. a stereo player with a single sample left in its buffer — realistic with a small `SetBufferSize`), `n / channelCount` is `0`, so `rateDenom` is `0`.

During a volume transition (`volume != prevVolume`), the ramp rate is then:

```go
rate := float32(i/channelCount) / rateDenom // = x/0 = +Inf, and 0/0 = NaN for i=0
```

`volume*Inf + prevVolume*(-Inf)` is NaN, so every sample of the ramp becomes NaN. The mixing loop drops non-finite values to protect other players, so **the entire ramp is dropped and the player outputs silence** until the next `SetVolume`.

### Reproduction

The following test passes on main (demonstrating the bug) and fails without this change:

```go
package mux

import (
	"math"
	"testing"
	"time"
)

type loudReader struct{}

func (loudReader) Read(p []byte) (int, error) {
	for i := range p {
		if i%4 < 2 {
			p[i] = 0xff // 16-bit stereo, 0x7fff = 0.99997
		} else {
			p[i] = 0x7f
		}
	}
	return len(p), nil
}

func TestVolumeRampNaN(t *testing.T) {
	m := New(48000, 2, FormatSignedInt16LE)
	p := m.NewPlayer(loudReader{})
	p.SetBufferSize(4) // one stereo sample
	p.Play()
	deadline := time.Now().Add(5 * time.Second)
	for p.BufferedSize() < 4 {
		if time.Now().After(deadline) {
			t.Fatal("buffer never filled")
		}
		time.Sleep(time.Millisecond)
	}
	p.SetVolume(0.5) // while playing: prevVolume (1) != volume (0.5)
	buf := make([]float32, 2)
	m.ReadFloat32s(buf)
	for i, v := range buf {
		if v == 0 || math.IsNaN(float64(v)) {
			t.Errorf("buf[%d] = %v: sample dropped by NaN ramp", i, v)
		}
	}
}
```

On main, both samples come out as `0` (dropped). With this PR, they are `±0.49998…` as expected.

### The fix

Divide floats:

```go
rateDenom := float32(n) / float32(channelCount)
```

The `float32(i/channelCount)` numerator is left as is: it is a per-frame index and the integer division there is intentional.