### PR TITLE
oto: fix a uint32 underflow of WASAPI write frames

### DIFF
--- a/driver_wasapi_windows.go
+++ b/driver_wasapi_windows.go
@@ -466,15 +466,16 @@ func (c *wasapiContext) writeOnRenderThread() error {
 		return err
 	}
 
-	// The subtraction must happen on signed ints: padding can exceed the buffer size
-	// transiently, and on uint32 that would wrap around to a huge frame count.
-	frames := int(c.bufferFrames) - int(paddingFrames)
-	if frames <= 0 {
+	// Defensive check: WASAPI should never report more padding than the buffer size,
+	// but if it did, the uint32 subtraction below would wrap around to a huge frame
+	// count and GetBuffer would fail, so skip the write instead.
+	if paddingFrames >= c.bufferFrames {
 		return nil
 	}
+	frames := c.bufferFrames - paddingFrames
 
 	// Get the destination buffer.
-	dstBuf, err := c.renderClient.GetBuffer(uint32(frames))
+	dstBuf, err := c.renderClient.GetBuffer(frames)
 	if err != nil {
 		return err
 	}
@@ -493,7 +494,7 @@ func (c *wasapiContext) writeOnRenderThread() error {
 	copy(unsafe.Slice((*float32)(unsafe.Pointer(dstBuf)), len(c.buf)), c.buf)
 
 	// Release the buffer.
-	if err := c.renderClient.ReleaseBuffer(uint32(frames), 0); err != nil {
+	if err := c.renderClient.ReleaseBuffer(frames, 0); err != nil {
 		return err
 	}
 

--- a/driver_wasapi_windows.go
+++ b/driver_wasapi_windows.go
@@ -466,13 +466,15 @@ func (c *wasapiContext) writeOnRenderThread() error {
 		return err
 	}
 
-	frames := c.bufferFrames - paddingFrames
+	// The subtraction must happen on signed ints: padding can exceed the buffer size
+	// transiently, and on uint32 that would wrap around to a huge frame count.
+	frames := int(c.bufferFrames) - int(paddingFrames)
 	if frames <= 0 {
 		return nil
 	}
 
 	// Get the destination buffer.
-	dstBuf, err := c.renderClient.GetBuffer(frames)
+	dstBuf, err := c.renderClient.GetBuffer(uint32(frames))
 	if err != nil {
 		return err
 	}
@@ -491,7 +493,7 @@ func (c *wasapiContext) writeOnRenderThread() error {
 	copy(unsafe.Slice((*float32)(unsafe.Pointer(dstBuf)), len(c.buf)), c.buf)
 
 	// Release the buffer.
-	if err := c.renderClient.ReleaseBuffer(frames, 0); err != nil {
+	if err := c.renderClient.ReleaseBuffer(uint32(frames), 0); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please adhere to our Code of Conduct:
https://go.dev/conduct
-->

# What issue is this addressing?
<!-- Closes #<issue number> | Updates #<issue number> -->

No issue filed yet. Found during an audit of the WASAPI driver.

## What _type_ of issue is this addressing?
<!-- bug | feature | security -->

bug

## What this PR does | solves
<!-- Please be as descriptive as possible -->

In `(*wasapiContext).writeOnRenderThread` (driver_wasapi_windows.go), both operands of the free-space calculation are `uint32`:

```go
bufferFrames     uint32            // c.bufferFrames
paddingFrames    uint32            // returned by IAudioClient2::GetCurrentPadding

frames := c.bufferFrames - paddingFrames
if frames <= 0 { // on uint32 this only catches the exact-zero case
	return nil
}
dstBuf, err := c.renderClient.GetBuffer(frames)
```

`GetCurrentPadding` is sampled asynchronously from the audio thread and can transiently report **more padding than the buffer size** (e.g. right after a device switch or while the event handler is delayed). On `uint32`, `bufferFrames - paddingFrames` then wraps around:

```
4096 - 5000 = 4294966392 (uint32)
```

The `frames <= 0` guard cannot catch this, and `GetBuffer` is called with ~4 billion frames. WASAPI rejects it with `AUDCLNT_E_BUFFER_TOO_LARGE`, `writeOnRenderThread` returns the error, `loopOnRenderThread` exits, and the whole context dies with a fatal error — instead of simply skipping one write.

### Reproduction

The wrap-around itself is plain Go semantics:

```go
var bufferFrames, paddingFrames uint32 = 4096, 5000
frames := bufferFrames - paddingFrames
fmt.Println(frames) // 4294966392 — "frames <= 0" is false
```

That a padding value larger than the buffer size is possible follows from the API contract: `GetCurrentPadding` is only documented as "the number of frames of padding" at the moment of the call, with no guarantee it is ≤ the buffer size obtained earlier (`GetBufferSize` is only read once at initialization), and the two calls are not atomic with the device state.

### The fix

Subtract in signed integers so that the existing `frames <= 0` guard actually works, and convert at the API boundaries:

```go
frames := int(c.bufferFrames) - int(paddingFrames)
if frames <= 0 {
	return nil
}
dstBuf, err := c.renderClient.GetBuffer(uint32(frames))
...
c.renderClient.ReleaseBuffer(uint32(frames), 0)
```

This makes the driver skip the write (as it already does for the `frames == 0` case) and recover on the next sample-ready event instead of tearing the context down.